### PR TITLE
Add GitHub Skills Activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills with GitHub. Part of our GitHub Certifications program to help with college applications",
+        "schedule": "Mondays and Thursdays, 3:30 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Summary
This PR adds the missing **GitHub Skills** activity to the extracurricular activities system, addressing the urgent request from students following the principal's assembly announcement.

## Changes
- Added "GitHub Skills" to the activities dictionary in `src/app.py`
- Description highlights the GitHub Certifications program and college application benefits
- Schedule: Mondays and Thursdays, 3:30 PM - 5:00 PM
- Capacity: 25 participants (anticipating high interest)
- Ready for immediate student registration

## Related Issue
Fixes #6 

## Impact
- Students can now register for the GitHub Skills activity before the end-of-week deadline
- Supports the school's partnership with GitHub
- Enables participation in the GitHub Certifications program

## Testing
- [x] Code has no syntax errors
- [x] Activity added to the existing data structure
- [x] Ready for deployment